### PR TITLE
[BLK-2023]

### DIFF
--- a/src/tasks/contract/pullcontract.ts
+++ b/src/tasks/contract/pullcontract.ts
@@ -8,7 +8,6 @@ import {
     SimbaConfig,
     pullSourceCodeForSimbaJson,
 } from '@simbachain/web3-suites';
-import { ContractDesignWithCode } from '@simbachain/web3-suites/dist/commands/contract';
 
 /**
  * when pulling your contracts from your blocks organisation, you can "pull" them

--- a/src/tasks/contract/pullcontract.ts
+++ b/src/tasks/contract/pullcontract.ts
@@ -6,7 +6,9 @@ import {
     pullMostRecentFromContractName,
     pullContractFromDesignId,
     SimbaConfig,
+    pullSourceCodeForSimbaJson,
 } from '@simbachain/web3-suites';
+import { ContractDesignWithCode } from '@simbachain/web3-suites/dist/commands/contract';
 
 /**
  * when pulling your contracts from your blocks organisation, you can "pull" them
@@ -48,7 +50,10 @@ const pull = async (
         return;
     }
     if (designID) {
-        await pullContractFromDesignId(designID, useSimbaPath);
+        const contractDesign = await pullContractFromDesignId(designID, useSimbaPath);
+        if (pullSourceCode && contractDesign) {
+            pullSourceCodeForSimbaJson(contractDesign)
+        }
         SimbaConfig.log.debug(`:: EXIT :`);
         return;
     }


### PR DESCRIPTION
updated pull from contract ID so that we are now also updating simba.json source code for that contract. so by default, if we pull a new contract based on design id, we will update our /contracts/ folder, as well as our simba.json.contracts_info.<contract-name> for that contract.